### PR TITLE
Split up the allTests job into separate targets based on platform

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -233,7 +233,7 @@ jobs:
           ./gradlew
           kotlinUpgradeYarnLock
           kotlinWasmUpgradeYarnLock
-          :samples:composeApp:assemble
+          :samples:composeApp:assembleDebug
 
   final-status:
     name: Final status check

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,8 +52,8 @@ jobs:
           -x wasmJsBrowserTest
           -x jvmTest
 
-  all-unit-tests:
-    name: All unit tests
+  jvm-tests:
+    name: JVM tests
     runs-on: macos-latest
     timeout-minutes: 60
     steps:
@@ -74,15 +74,11 @@ jobs:
           build-scan-terms-of-use-url: "https://gradle.com/terms-of-service"
           build-scan-terms-of-use-agree: "yes"
 
-      - name: Run all tests
-        run: >
-          ./gradlew
-          kotlinUpgradeYarnLock
-          kotlinWasmUpgradeYarnLock
-          :liquid:allTests
+      - name: Run JVM tests
+        run: ./gradlew :liquid:jvmTest
 
-  assemble:
-    name: Assemble samples
+  ios-tests:
+    name: iOS tests
     runs-on: macos-latest
     timeout-minutes: 60
     steps:
@@ -103,12 +99,8 @@ jobs:
           build-scan-terms-of-use-url: "https://gradle.com/terms-of-service"
           build-scan-terms-of-use-agree: "yes"
 
-      - name: Assemble samples
-        run: >
-          ./gradlew
-          kotlinUpgradeYarnLock
-          kotlinWasmUpgradeYarnLock
-          :samples:composeApp:assembleDebug
+      - name: Run iOS tests
+        run: ./gradlew :liquid:iosSimulatorArm64Test
 
   android-instrumentation-tests:
     name: Android emulator tests
@@ -214,11 +206,40 @@ jobs:
           path: '**/build/outputs/roborazzi/*_compare.png'
           retention-days: 1
 
+  assemble:
+    name: Assemble samples
+    runs-on: macos-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Java version
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'zulu'
+          java-version-file: .github/workflows/.java-version
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v5
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          build-scan-publish: true
+          build-scan-terms-of-use-url: "https://gradle.com/terms-of-service"
+          build-scan-terms-of-use-agree: "yes"
+
+      - name: Assemble samples
+        run: >
+          ./gradlew
+          kotlinUpgradeYarnLock
+          kotlinWasmUpgradeYarnLock
+          :samples:composeApp:assemble
+
   final-status:
     name: Final status check
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
-    needs: [check-no-tests, all-unit-tests, assemble, android-instrumentation-tests, screenshot-tests]
+    needs: [check-no-tests, jvm-tests, ios-tests, android-instrumentation-tests, screenshot-tests, assemble]
     steps:
       - name: Final status check
         run: |
@@ -242,9 +263,12 @@ jobs:
 
       - uses: gradle/actions/setup-gradle@v5
         with:
-          cache-disabled: true
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          build-scan-publish: true
+          build-scan-terms-of-use-url: "https://gradle.com/terms-of-service"
+          build-scan-terms-of-use-agree: "yes"
 
-      - run: ./gradlew publish --no-configuration-cache
+      - run: ./gradlew publishToMavenCentral
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_CENTRAL_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_CENTRAL_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v5
 
       - name: Publish artifacts
-        run: ./gradlew publish --no-configuration-cache
+        run: ./gradlew publishToMavenCentral --no-configuration-cache
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_CENTRAL_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_CENTRAL_PASSWORD }}


### PR DESCRIPTION
- The allTests is a bottleneck and we weren't getting any of the cache benefits because of the kotlinUpgradeYarnLock/kotlinWasmUpgradeYarnLock tasks. We don't need those considering the js test tasks are disabled until those targets become more stable. This should speed up those steps which may allow us to use assemble instead of assembleDebug as I don't think we were getting much coverage outside of android with assembleDebug. There's a good chance we'll have to keep it as assembleDebug as assemble will likely take too long, but figured it was worth trying.
- Looking at the vanniktech release notes, it looks like it shouldn't be an issue using configuration-cache when publishing snapshots, so seeing if this helps with the issue that was causing failures. We'll keep the release.yml as is with --no-configuration-cache.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
