### PR TITLE
Clamping cornerRadii to 50% of the minDimension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+Fixed:
+- Corner radii are clamped to 50% of the minimum dimension ([#82](https://github.com/FletchMcKee/liquid/pull/81)).
+
 ## [1.0.1] - 2025-11-18
 
 New:

--- a/liquid/src/commonMain/kotlin/io/github/fletchmckee/liquid/internal/AbstractLiquidElement.kt
+++ b/liquid/src/commonMain/kotlin/io/github/fletchmckee/liquid/internal/AbstractLiquidElement.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.node.observeReads
 import androidx.compose.ui.platform.InspectorInfo
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalGraphicsContext
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.toSize
 import androidx.compose.ui.util.fastFilter
 import io.github.fletchmckee.liquid.LiquidScope
@@ -108,6 +109,8 @@ internal abstract class AbstractLiquidNode(
     // Our frostRadius calculations rely on density. Setting it here prevents unnecessary RenderEffect
     // invalidations in the draw pass.
     reusableScope.density = currentValueOf(LocalDensity)
+    // The cornerRadii ordering depends on layoutDirection.
+    reusableScope.layoutDirection = currentValueOf(LocalLayoutDirection)
     block(reusableScope)
 
     // Changes to `liquefiables` should be tracked, not ancestors.

--- a/liquid/src/commonMain/kotlin/io/github/fletchmckee/liquid/internal/InternalLiquidScope.kt
+++ b/liquid/src/commonMain/kotlin/io/github/fletchmckee/liquid/internal/InternalLiquidScope.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import io.github.fletchmckee.liquid.Liquefiable
 import io.github.fletchmckee.liquid.LiquidScope
@@ -20,6 +21,7 @@ import io.github.fletchmckee.liquid.LiquidScope
 // These fields are configured internally so we don't expose them as public API, but they have to be set externally.
 internal interface InternalLiquidScope : LiquidScope {
   var density: Density
+  var layoutDirection: LayoutDirection
   var size: Size
   var positionOnScreen: Offset
   var inverseScaleX: Float
@@ -54,7 +56,7 @@ internal class LiquidScopeImpl : InternalLiquidScope {
         // Similar to tint, we don't really care about the shape interface, we just need the corner radii,
         // so the mutatedFields tracker is set there.
         if (size.isSpecified) {
-          cornerRadii = value.cornerRadiiPx(size, density)
+          cornerRadii = value.normalizedCornerRadii(size, density, layoutDirection)
         }
       }
     }
@@ -118,13 +120,25 @@ internal class LiquidScopeImpl : InternalLiquidScope {
       }
     }
 
+  override var layoutDirection: LayoutDirection = LayoutDirection.Ltr
+    set(value) {
+      if (field != value) {
+        // Doesn't need its own mutatedFields tracker as we only care about changes to cornerRadii.
+        // Also even if this did change frequently, most use cases will have uniform cornerRadii.
+        field = value
+        if (size.isSpecified) {
+          cornerRadii = shape.normalizedCornerRadii(size, density, value)
+        }
+      }
+    }
+
   override var size: Size = Size.Unspecified
     set(value) {
       if (field != value) {
         mutatedFields = mutatedFields or Fields.Size
         field = value
         if (value.isSpecified) {
-          cornerRadii = shape.cornerRadiiPx(value, density)
+          cornerRadii = shape.normalizedCornerRadii(value, density, layoutDirection)
         }
       }
     }

--- a/liquid/src/commonMain/kotlin/io/github/fletchmckee/liquid/internal/drawUtil.kt
+++ b/liquid/src/commonMain/kotlin/io/github/fletchmckee/liquid/internal/drawUtil.kt
@@ -6,7 +6,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
-import androidx.compose.ui.geometry.takeOrElse
+import androidx.compose.ui.geometry.isUnspecified
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Outline
@@ -19,8 +19,10 @@ import androidx.compose.ui.graphics.drawscope.withTransform
 import androidx.compose.ui.graphics.layer.GraphicsLayer
 import androidx.compose.ui.graphics.layer.drawLayer
 import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.toIntSize
+import androidx.compose.ui.util.fastCoerceAtMost
 import androidx.compose.ui.util.fastFilter
 import androidx.compose.ui.util.fastForEach
 import io.github.fletchmckee.liquid.internal.LiquidScopeImpl.Companion.Float4Zero
@@ -29,6 +31,7 @@ internal fun ContentDrawScope.recordLiquefiablesIntoLayer(
   layer: GraphicsLayer,
   reusableScope: InternalLiquidScope,
 ) = with(reusableScope) {
+  if (positionOnScreen.isUnspecified) return@with
   // Only record content inside the effect's bounds.
   val liquefiables = liquefiables.fastFilter { boundsInRoot.overlaps(it.boundsOnScreen) }
   if (liquefiables.isEmpty()) return@with
@@ -40,7 +43,7 @@ internal fun ContentDrawScope.recordLiquefiablesIntoLayer(
         ?.takeUnless { it.isReleased }
         ?.let { liquefiableLayer ->
           // Position content where it should appear on screen.
-          val (x, y) = liquefiable.boundsOnScreen.topLeft.orZero - positionOnScreen.orZero
+          val (x, y) = liquefiable.boundsOnScreen.topLeft - positionOnScreen
           withTransform(
             {
               rotate(degrees = inverseRotationZ, pivot = Offset.Zero)
@@ -60,28 +63,64 @@ internal fun ContentDrawScope.recordLiquefiablesIntoLayer(
  * along with being used in our liquid nodes.
  */
 @androidx.annotation.Size(value = 4)
-internal fun Shape.cornerRadiiPx(size: Size, density: Density): FloatArray = when (this) {
+internal fun Shape.normalizedCornerRadii(
+  size: Size,
+  density: Density,
+  layoutDirection: LayoutDirection = LayoutDirection.Ltr,
+): FloatArray = when (this) {
   CircleShape -> {
     floatArrayOf(0.5f, 0.5f, 0.5f, 0.5f)
   }
   is RoundedCornerShape -> {
-    if (size.minDimension <= 0) {
-      Float4Zero
-    } else {
-      // Unlike the effectRect that is LTRB, the shader's cornerRadii is quadrant based where the order is:
-      // bottomEnd, topEnd, bottomStart, topStart.
-      floatArrayOf(
-        bottomEnd.toPx(size, density) / size.minDimension,
-        topEnd.toPx(size, density) / size.minDimension,
-        bottomStart.toPx(size, density) / size.minDimension,
-        topStart.toPx(size, density) / size.minDimension,
-      )
+    when {
+      size.minDimension <= 0 -> Float4Zero
+      else -> {
+        // Similar to the logic in CornerBasedShape, but normalized by the minDimension.
+        var topStart = topStart.toPx(size, density)
+        var topEnd = topEnd.toPx(size, density)
+        var bottomEnd = bottomEnd.toPx(size, density)
+        var bottomStart = bottomStart.toPx(size, density)
+        val minDimension = size.minDimension
+
+        if (topStart + bottomStart > minDimension) {
+          val scale = 1f / (topStart + bottomStart)
+          topStart *= scale
+          bottomStart *= scale
+        } else {
+          topStart /= minDimension
+          bottomStart /= minDimension
+        }
+
+        if (topEnd + bottomEnd > minDimension) {
+          val scale = 1f / (topEnd + bottomEnd)
+          topEnd *= scale
+          bottomEnd *= scale
+        } else {
+          topEnd /= minDimension
+          bottomEnd /= minDimension
+        }
+
+        // Users can clip if they want a shape with radii > 50%, but we have to cap the
+        // max value at 0.5f to prevent sdf artifacts.
+        when (layoutDirection) {
+          LayoutDirection.Ltr -> floatArrayOf(
+            bottomEnd.fastCoerceAtMost(0.5f),
+            topEnd.fastCoerceAtMost(0.5f),
+            bottomStart.fastCoerceAtMost(0.5f),
+            topStart.fastCoerceAtMost(0.5f),
+          )
+          LayoutDirection.Rtl -> floatArrayOf(
+            bottomStart.fastCoerceAtMost(0.5f),
+            topStart.fastCoerceAtMost(0.5f),
+            bottomEnd.fastCoerceAtMost(0.5f),
+            topEnd.fastCoerceAtMost(0.5f),
+          )
+        }
+      }
     }
   }
   else -> Float4Zero
 }
-
-internal inline val Offset.orZero: Offset get() = takeOrElse { Offset.Zero }
 
 @Suppress("NOTHING_TO_INLINE")
 internal inline infix fun Int.has(flag: Int): Boolean = (this and flag) != 0

--- a/liquid/src/commonTest/kotlin/io/github/fletchmckee/liquid/DrawUtilTest.kt
+++ b/liquid/src/commonTest/kotlin/io/github/fletchmckee/liquid/DrawUtilTest.kt
@@ -1,0 +1,135 @@
+// Copyright 2025, Colin McKee
+// SPDX-License-Identifier: Apache-2.0
+package io.github.fletchmckee.liquid
+
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.hasSize
+import assertk.assertions.isCloseTo
+import assertk.assertions.isEqualTo
+import io.github.fletchmckee.liquid.internal.normalizedCornerRadii
+import kotlin.test.Test
+
+class DrawUtilTest {
+  @Test fun normalizedCornerRadii_circleShapeIs50Percent() {
+    val result = CircleShape.normalizedCornerRadii(sizeHundred, densityOne)
+    assertThat(result).all {
+      hasSize(4)
+      // This shouldn't have any precision issues.
+      isEqualTo(floatArrayOf(0.5f, 0.5f, 0.5f, 0.5f))
+    }
+  }
+
+  @Test fun normalizedCornerRadii_rectangleShapeIs0Percent() {
+    val result = RectangleShape.normalizedCornerRadii(sizeHundred, densityOne)
+    assertThat(result).all {
+      hasSize(4)
+      // This shouldn't have any precision issues.
+      isEqualTo(floatArrayOf(0f, 0f, 0f, 0f))
+    }
+  }
+
+  @Test fun normalizedCornerRadii_roundedCornerShapeSub50() {
+    val result = RoundedCornerShape(25).normalizedCornerRadii(sizeHundred, densityOne)
+    assertThat(result).all {
+      hasSize(4)
+      // This shouldn't have any precision issues.
+      isEqualTo(floatArrayOf(0.25f, 0.25f, 0.25f, 0.25f))
+    }
+  }
+
+  @Test fun normalizedCornerRadii_densityCalculatedCorrectly() {
+    val densityTwo = Density(2f)
+    val sizeResult = RoundedCornerShape(20.dp).normalizedCornerRadii(sizeHundred, densityTwo)
+    assertThat(sizeResult).all {
+      hasSize(4)
+      // 20.dp with 2f density results in 0.4f radii.
+      isEqualTo(floatArrayOf(0.4f, 0.4f, 0.4f, 0.4f))
+    }
+
+    val dpSizeResult = RoundedCornerShape(20.dp).normalizedCornerRadii(
+      size = with(densityTwo) { DpSize(width = 100.dp, height = 100.dp).toSize() },
+      density = densityTwo,
+    )
+    assertThat(dpSizeResult).all {
+      hasSize(4)
+      // DpSize is adjusted with the same density.
+      isEqualTo(floatArrayOf(0.2f, 0.2f, 0.2f, 0.2f))
+    }
+  }
+
+  @Test fun normalizedCornerRadii_minDimensionIsRespected() {
+    val portraitResult = RoundedCornerShape(25).normalizedCornerRadii(
+      size = Size(width = 100f, height = 200f),
+      density = densityOne,
+    )
+    assertThat(portraitResult).all {
+      hasSize(4)
+      // This shouldn't have any precision issues.
+      isEqualTo(floatArrayOf(0.25f, 0.25f, 0.25f, 0.25f))
+    }
+
+    val landscapeResult = RoundedCornerShape(25).normalizedCornerRadii(
+      size = Size(width = 200f, height = 100f),
+      density = densityOne,
+    )
+    assertThat(landscapeResult).all {
+      hasSize(4)
+      // This shouldn't have any precision issues.
+      isEqualTo(floatArrayOf(0.25f, 0.25f, 0.25f, 0.25f))
+    }
+  }
+
+  @Test fun normalizedCornerRadii_clampsRadiiTo50Percent() {
+    val shape = RoundedCornerShape(
+      bottomEndPercent = 40,
+      topEndPercent = 50,
+      bottomStartPercent = 100,
+      topStartPercent = 60,
+    )
+
+    val result = shape.normalizedCornerRadii(sizeHundred, densityOne)
+    assertThat(result).hasSize(4)
+    assertThat(result[0]).isEqualTo(0.4f)
+    assertThat(result[1]).isEqualTo(0.5f)
+    // Verify this one is clamped and not 0.625f.
+    assertThat(result[2]).isEqualTo(0.5f)
+    // scale = 1f / (bottomStart + topStart) = 0.00625
+    // topStart = 60px * 0.00625 = 0.375
+    assertThat(result[3]).isCloseTo(0.375f, Delta)
+  }
+
+  @Test fun normalizedCornerRadii_rtlIsSupported() {
+    val shape = RoundedCornerShape(
+      bottomEndPercent = 40,
+      topEndPercent = 50,
+      bottomStartPercent = 100,
+      topStartPercent = 60,
+    )
+
+    val result = shape.normalizedCornerRadii(sizeHundred, densityOne, LayoutDirection.Rtl)
+    assertThat(result).hasSize(4)
+    // Verify this one is clamped
+    assertThat(result[0]).isEqualTo(0.5f)
+    // scale = 1f / (bottomStart + topStart) = 0.00625
+    // topStart = 60px * 0.00625 = 0.375
+    assertThat(result[1]).isCloseTo(0.375f, Delta)
+    assertThat(result[2]).isEqualTo(0.4f)
+    assertThat(result[3]).isEqualTo(0.5f)
+  }
+
+  @Suppress("ConstPropertyName")
+  private companion object {
+    const val Delta = 0.001f
+    val sizeHundred = Size(width = 100f, height = 100f)
+    val densityOne = Density(density = 1f)
+  }
+}

--- a/liquid/src/commonTest/kotlin/io/github/fletchmckee/liquid/LiquidScopeTest.kt
+++ b/liquid/src/commonTest/kotlin/io/github/fletchmckee/liquid/LiquidScopeTest.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import assertk.assertThat
 import assertk.assertions.isEmpty
@@ -37,6 +38,8 @@ class LiquidScopeTest {
     assertThat(scope.saturation).isEqualTo(1f)
     assertThat(scope.dispersion).isZero()
     assertThat(scope.argbColor).isZero()
+    assertThat(scope.density).isEqualTo(Density(1f))
+    assertThat(scope.layoutDirection).isEqualTo(LayoutDirection.Ltr)
     assertThat(scope.size).isEqualTo(Size.Unspecified)
     assertThat(scope.positionOnScreen).isEqualTo(Offset.Unspecified)
     assertThat(scope.inverseScaleX).isEqualTo(1f)
@@ -207,6 +210,38 @@ class LiquidScopeTest {
     // Verify the RenderEffect and InvalidateFlags are not 0.
     assertThat(scope.mutatedFields and Fields.RenderEffectFields).isNotZero()
     assertThat(scope.mutatedFields and Fields.InvalidateFlags).isNotZero()
+  }
+
+  @Test fun layoutDirectionMutationsUpdateCornerRadii() {
+    scope.size = Size(width = 100f, height = 100f)
+    scope.clean() // We just want to verify layoutDirection changes.
+    scope.layoutDirection = LayoutDirection.Ltr
+    scope.shape = RoundedCornerShape(
+      bottomEndPercent = 10,
+      topEndPercent = 20,
+      bottomStartPercent = 30,
+      topStartPercent = 40,
+    )
+    assertThat(scope.cornerRadii).isEqualTo(floatArrayOf(0.1f, 0.2f, 0.3f, 0.4f))
+    assertThat(scope.mutatedFields).isEqualTo(Fields.Shape)
+    // Verify the RenderEffect and InvalidateFlags are not 0.
+    assertThat(scope.mutatedFields and Fields.RenderEffectFields).isNotZero()
+    assertThat(scope.mutatedFields and Fields.InvalidateFlags).isNotZero()
+    scope.clean() // Clean the tracker.
+
+    scope.layoutDirection = LayoutDirection.Rtl
+    // Verify the ends and starts flipped.
+    assertThat(scope.cornerRadii).isEqualTo(floatArrayOf(0.3f, 0.4f, 0.1f, 0.2f))
+    assertThat(scope.mutatedFields).isEqualTo(Fields.Shape)
+    // Verify the RenderEffect and InvalidateFlags are not 0.
+    assertThat(scope.mutatedFields and Fields.RenderEffectFields).isNotZero()
+    assertThat(scope.mutatedFields and Fields.InvalidateFlags).isNotZero()
+    scope.clean()
+
+    // Verify resetting the same layoutDirection does not invalidate any flags.
+    scope.layoutDirection = LayoutDirection.Rtl
+    assertThat(scope.mutatedFields and Fields.RenderEffectFields).isZero()
+    assertThat(scope.mutatedFields and Fields.InvalidateFlags).isZero()
   }
 
   private fun LiquidScope.setNonDefaultValues() {


### PR DESCRIPTION
Addressing this [issue](https://github.com/FletchMcKee/liquid/issues/80)

- Also adjusted the calculation to match the CornerBasedShape calculation, with the exception that we have to clamp it. Otherwise we get bizarre effects and if users really want some irregular shapes, they can still clip it.
- Also added support for LayoutDirection.Rtl, although most use cases will likely have horizontally symmetrical shapes.

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
