### PR TITLE
Deprecated the LiquidState public constructor

### DIFF
--- a/liquid/build.gradle.kts
+++ b/liquid/build.gradle.kts
@@ -6,7 +6,6 @@ import com.vanniktech.maven.publish.KotlinMultiplatform
 import kotlinx.validation.ExperimentalBCVApi
 import org.jetbrains.compose.ExperimentalComposeLibrary
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSetTree
 import org.jetbrains.kotlin.gradle.targets.js.testing.KotlinJsTest
 
@@ -27,11 +26,11 @@ kotlin {
   explicitApi()
   addDefaultLiquidTargets()
 
-  androidTarget {
-    compilerOptions {
-      jvmTarget.set(JvmTarget.JVM_11)
-    }
+  compilerOptions {
+    allWarningsAsErrors = true
+  }
 
+  androidTarget {
     @OptIn(ExperimentalKotlinGradlePluginApi::class)
     instrumentedTestVariant.sourceSetTree.set(KotlinSourceSetTree.test)
   }

--- a/liquid/src/commonMain/kotlin/io/github/fletchmckee/liquid/Liquefiable.kt
+++ b/liquid/src/commonMain/kotlin/io/github/fletchmckee/liquid/Liquefiable.kt
@@ -3,13 +3,7 @@
 package io.github.fletchmckee.liquid
 
 import androidx.compose.runtime.Stable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Rect
-import androidx.compose.ui.graphics.layer.GraphicsLayer
 import io.github.fletchmckee.liquid.internal.LiquefiableElement
 
 /**
@@ -43,19 +37,3 @@ import io.github.fletchmckee.liquid.internal.LiquefiableElement
 public fun Modifier.liquefiable(
   liquidState: LiquidState,
 ): Modifier = this then LiquefiableElement(liquidState)
-
-@Stable
-internal class Liquefiable {
-  internal var layer: GraphicsLayer? by mutableStateOf(null)
-  internal var boundsOnScreen: Rect by mutableStateOf(Rect.Zero)
-
-  // Avoids triggering recomposition when logs read this object.
-  override fun toString(): String = Snapshot.withoutReadObservation {
-    """
-    Liquefiable(
-      layer=$layer,
-      boundsOnScreen=$boundsOnScreen,
-    )
-    """.trimIndent()
-  }
-}

--- a/liquid/src/commonMain/kotlin/io/github/fletchmckee/liquid/Liquid.kt
+++ b/liquid/src/commonMain/kotlin/io/github/fletchmckee/liquid/Liquid.kt
@@ -7,13 +7,20 @@ import androidx.compose.runtime.Stable
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import io.github.fletchmckee.liquid.internal.Liquefiable
 import io.github.fletchmckee.liquid.internal.liquidElement
 
 /**
  * State manager of recorded [Liquefiable] nodes to be rendered into [liquid] effect nodes.
  */
 @Stable
-public class LiquidState {
+public class LiquidState
+@Deprecated(
+  message = "Use rememberLiquidState instead.",
+  replaceWith = ReplaceWith("rememberLiquidState()"),
+  level = DeprecationLevel.WARNING,
+)
+public constructor() {
   internal val liquefiables = mutableStateListOf<Liquefiable>()
 }
 
@@ -34,6 +41,7 @@ public class LiquidState {
  *
  * @return a stable [LiquidState] that survives recomposition.
  */
+@Suppress("Deprecation") // Can remove once the LiquidState constructor is internal.
 @Composable
 public fun rememberLiquidState(): LiquidState = remember { LiquidState() }
 

--- a/liquid/src/commonMain/kotlin/io/github/fletchmckee/liquid/internal/InternalLiquidScope.kt
+++ b/liquid/src/commonMain/kotlin/io/github/fletchmckee/liquid/internal/InternalLiquidScope.kt
@@ -15,7 +15,6 @@ import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
-import io.github.fletchmckee.liquid.Liquefiable
 import io.github.fletchmckee.liquid.LiquidScope
 
 // These fields are configured internally so we don't expose them as public API, but they have to be set externally.

--- a/liquid/src/commonMain/kotlin/io/github/fletchmckee/liquid/internal/LiquefiableElement.kt
+++ b/liquid/src/commonMain/kotlin/io/github/fletchmckee/liquid/internal/LiquefiableElement.kt
@@ -2,10 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.github.fletchmckee.liquid.internal
 
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.drawscope.ContentDrawScope
+import androidx.compose.ui.graphics.layer.GraphicsLayer
 import androidx.compose.ui.graphics.layer.drawLayer
 import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.node.CompositionLocalConsumerModifierNode
@@ -17,8 +22,23 @@ import androidx.compose.ui.node.currentValueOf
 import androidx.compose.ui.platform.InspectorInfo
 import androidx.compose.ui.platform.LocalGraphicsContext
 import androidx.compose.ui.unit.toSize
-import io.github.fletchmckee.liquid.Liquefiable
 import io.github.fletchmckee.liquid.LiquidState
+
+@Stable
+internal class Liquefiable {
+  internal var layer: GraphicsLayer? by mutableStateOf(null)
+  internal var boundsOnScreen: Rect by mutableStateOf(Rect.Zero)
+
+  // Avoids state tracking when used for logs.
+  override fun toString(): String = Snapshot.withoutReadObservation {
+    """
+    Liquefiable(
+      layer=$layer,
+      boundsOnScreen=$boundsOnScreen,
+    )
+    """.trimIndent()
+  }
+}
 
 internal class LiquefiableElement(
   private val liquidState: LiquidState,

--- a/liquid/src/commonTest/kotlin/io/github/fletchmckee/liquid/LiquefiableNodeTest.kt
+++ b/liquid/src/commonTest/kotlin/io/github/fletchmckee/liquid/LiquefiableNodeTest.kt
@@ -37,6 +37,7 @@ class LiquefiableNodeTest {
   private lateinit var liquidState: LiquidState
 
   @BeforeTest fun setUp() {
+    @Suppress("Deprecation")
     liquidState = LiquidState()
   }
 

--- a/liquid/src/commonTest/kotlin/io/github/fletchmckee/liquid/LiquidNodeTest.kt
+++ b/liquid/src/commonTest/kotlin/io/github/fletchmckee/liquid/LiquidNodeTest.kt
@@ -43,6 +43,7 @@ class LiquidNodeTest {
   private lateinit var liquidState: LiquidState
 
   @BeforeTest fun setUp() {
+    @Suppress("Deprecation") // Can remove once the constructor is internal.
     liquidState = LiquidState()
   }
 
@@ -77,7 +78,9 @@ class LiquidNodeTest {
     var offset by mutableStateOf(IntOffset(0))
     var drawCount = 0
     var liquidBlockCount = 0
+
     // Own unique LiquidState
+    @Suppress("Deprecation") // Can remove once the constructor is internal.
     val liquidNode = LiquidNode(LiquidState()) { liquidBlockCount++ }
     setContent {
       Parent {

--- a/liquid/src/commonTest/kotlin/io/github/fletchmckee/liquid/LiquidScopeTest.kt
+++ b/liquid/src/commonTest/kotlin/io/github/fletchmckee/liquid/LiquidScopeTest.kt
@@ -17,6 +17,7 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isNotZero
 import assertk.assertions.isZero
 import io.github.fletchmckee.liquid.internal.Fields
+import io.github.fletchmckee.liquid.internal.Liquefiable
 import io.github.fletchmckee.liquid.internal.LiquidScopeImpl
 import kotlin.test.BeforeTest
 import kotlin.test.Test

--- a/liquid/src/commonTest/kotlin/io/github/fletchmckee/liquid/internal/DrawUtilTest.kt
+++ b/liquid/src/commonTest/kotlin/io/github/fletchmckee/liquid/internal/DrawUtilTest.kt
@@ -1,6 +1,6 @@
 // Copyright 2025, Colin McKee
 // SPDX-License-Identifier: Apache-2.0
-package io.github.fletchmckee.liquid
+package io.github.fletchmckee.liquid.internal
 
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -15,7 +15,6 @@ import assertk.assertThat
 import assertk.assertions.hasSize
 import assertk.assertions.isCloseTo
 import assertk.assertions.isEqualTo
-import io.github.fletchmckee.liquid.internal.normalizedCornerRadii
 import kotlin.test.Test
 
 class DrawUtilTest {


### PR DESCRIPTION
- I should have made this internal from the beginning but it was an oversight. Users have no reason to use this constructor and it would only cause issues if using it as a default param in Composables instead of `rememberLiquidState` as it won't survive recompositions.
- Also took this opportunity to move the Liquefiable state class into the internal directory since it is an internal class. This was at one time public which is why it was there, but fortunately it was made internal before any release.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
