### PR TITLE
Updated top sdk for android tests from 35 to 36

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,7 +109,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        api-level: [ 33, 35 ]
+        api-level: [ 33, 36 ]
 
     steps:
       - uses: actions/checkout@v6

--- a/core/testing/src/androidMain/kotlin/io/github/fletchmckee/liquid/core/testing/testUtils.android.kt
+++ b/core/testing/src/androidMain/kotlin/io/github/fletchmckee/liquid/core/testing/testUtils.android.kt
@@ -19,7 +19,7 @@ import org.robolectric.annotation.GraphicsMode
 
 @RunWith(AndroidJUnit4::class)
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
-@Config(sdk = [31, 35], qualifiers = RobolectricDeviceQualifiers.Pixel7)
+@Config(sdk = [31, 36], qualifiers = RobolectricDeviceQualifiers.Pixel7)
 actual abstract class ScreenshotTest
 
 actual fun runScreenshotTest(

--- a/samples/shared/build.gradle.kts
+++ b/samples/shared/build.gradle.kts
@@ -21,6 +21,10 @@ kotlin {
   androidLibrary {
     namespace = "io.github.fletchmckee.liquid.samples.shared"
     androidResources.enable = true
+
+    withHostTest {
+      isIncludeAndroidResources = true
+    }
   }
 
   listOf(

--- a/samples/shared/screenshots/android/LiquidScreenshotTest.capture_clock_10_dp_frost[35].png
+++ b/samples/shared/screenshots/android/LiquidScreenshotTest.capture_clock_10_dp_frost[35].png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ff6257cc951cd0653ca714e3313602559fe5f0513a564bcb7faa41f082ebf73f
-size 3440843

--- a/samples/shared/screenshots/android/LiquidScreenshotTest.capture_clock_10_dp_frost[36].png
+++ b/samples/shared/screenshots/android/LiquidScreenshotTest.capture_clock_10_dp_frost[36].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2079bfab691cc5bdb8ee872f4ede0fcd3596dffba958ecd2648d713d32cfc916
+size 3440863

--- a/samples/shared/screenshots/android/LiquidScreenshotTest.capture_clock_no_frost[35].png
+++ b/samples/shared/screenshots/android/LiquidScreenshotTest.capture_clock_no_frost[35].png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c314153f3625a0629b51d58ce507adcf2bf000fda3621ddcec5230c8c17756b0
-size 3977837

--- a/samples/shared/screenshots/android/LiquidScreenshotTest.capture_clock_no_frost[36].png
+++ b/samples/shared/screenshots/android/LiquidScreenshotTest.capture_clock_no_frost[36].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1928cf59828def03ff0ea50d326e55937549d9b7990dfcf09b219b84757dc57c
+size 3977801

--- a/samples/shared/screenshots/android/LiquidScreenshotTest.capture_clock_quarter_dispersion_no_frost[35].png
+++ b/samples/shared/screenshots/android/LiquidScreenshotTest.capture_clock_quarter_dispersion_no_frost[35].png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8295325295e2c8eaf5c905a031f5de33a1c4aa3d6866fd3c810e946ae6cd10bf
-size 4204330

--- a/samples/shared/screenshots/android/LiquidScreenshotTest.capture_clock_quarter_dispersion_no_frost[36].png
+++ b/samples/shared/screenshots/android/LiquidScreenshotTest.capture_clock_quarter_dispersion_no_frost[36].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c2e251e501c547e2f1ff18801fa33118cb0546afb3ae658821716b6dc4d1aee
+size 4204354

--- a/samples/shared/screenshots/android/LiquidScreenshotTest.capture_drag_10_dp_frost[35].png
+++ b/samples/shared/screenshots/android/LiquidScreenshotTest.capture_drag_10_dp_frost[35].png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:98c6d951b070ffa775f34a5a2d066c6329b597cbc9cc532d16b82702264d34c9
-size 1812135

--- a/samples/shared/screenshots/android/LiquidScreenshotTest.capture_drag_10_dp_frost[36].png
+++ b/samples/shared/screenshots/android/LiquidScreenshotTest.capture_drag_10_dp_frost[36].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:959e2338917a7ebb5b80247e2c913cbc653664f327800baea502a68ad06aba8c
+size 1812971

--- a/samples/shared/screenshots/android/LiquidScreenshotTest.capture_drag_half_dispersion[35].png
+++ b/samples/shared/screenshots/android/LiquidScreenshotTest.capture_drag_half_dispersion[35].png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4ada6b14ebf049c04fa02bf4c89f7a2b6401d4ca2aaa92ff7ab159ca18499afc
-size 2091076

--- a/samples/shared/screenshots/android/LiquidScreenshotTest.capture_drag_half_dispersion[36].png
+++ b/samples/shared/screenshots/android/LiquidScreenshotTest.capture_drag_half_dispersion[36].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1552afe8d3a5933a695891dfd0302edd7eb6144e2bc18952cb75cc479747b72b
+size 2091978

--- a/samples/shared/screenshots/android/LiquidScreenshotTest.capture_drag_no_frost[35].png
+++ b/samples/shared/screenshots/android/LiquidScreenshotTest.capture_drag_no_frost[35].png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:caf8b86eef58c15cafbf31e585d2f505b46569cf202cf6c963e1e444a66334a8
-size 1925869

--- a/samples/shared/screenshots/android/LiquidScreenshotTest.capture_drag_no_frost[36].png
+++ b/samples/shared/screenshots/android/LiquidScreenshotTest.capture_drag_no_frost[36].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6778a53d5015cdcac4c97de969204624062d3ea02dc0c228517cb4d63dc3cf59
+size 1926724

--- a/samples/shared/screenshots/android/LiquidScreenshotTest.capture_grid_no_frost[35].png
+++ b/samples/shared/screenshots/android/LiquidScreenshotTest.capture_grid_no_frost[35].png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1f1c42b2f41c8905f276c0bbbe4a5f7f59ef90ebb7cf4b4a336a9022b20b8713
-size 2597378

--- a/samples/shared/screenshots/android/LiquidScreenshotTest.capture_grid_no_frost[36].png
+++ b/samples/shared/screenshots/android/LiquidScreenshotTest.capture_grid_no_frost[36].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2420c11985498ded235534fa273c678c907eb3605445303192115fc5a05314fe
+size 2597380

--- a/samples/shared/screenshots/android/LiquidScreenshotTest.capture_many_liquid_nodes_20_dp_frost[31].png
+++ b/samples/shared/screenshots/android/LiquidScreenshotTest.capture_many_liquid_nodes_20_dp_frost[31].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:49e57133898b9ba0607484782dc93d9148f25f01a4efeada331dddffc0b8b807
-size 2445409
+oid sha256:f2ce883e79588a93d6208b5513ec6bbdfc513807468d758faf048a4582a02a47
+size 2419194

--- a/samples/shared/screenshots/android/LiquidScreenshotTest.capture_many_liquid_nodes_20_dp_frost[35].png
+++ b/samples/shared/screenshots/android/LiquidScreenshotTest.capture_many_liquid_nodes_20_dp_frost[35].png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:016d4fb12e439b954fa077be7ad1300ee301318092a68632dc4a5f8afa0efffe
-size 2404416

--- a/samples/shared/screenshots/android/LiquidScreenshotTest.capture_many_liquid_nodes_20_dp_frost[36].png
+++ b/samples/shared/screenshots/android/LiquidScreenshotTest.capture_many_liquid_nodes_20_dp_frost[36].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b78e934e33f87eeb9e96ca452acc053b3e53c831585856567a1ef039d818807
+size 2404400

--- a/samples/shared/screenshots/android/LiquidScreenshotTest.capture_sticky_header_10_dp_frost_scrolled[35].png
+++ b/samples/shared/screenshots/android/LiquidScreenshotTest.capture_sticky_header_10_dp_frost_scrolled[35].png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e74c3041c0a1f983eb3affbd242a7257f202279e670c84ac566cdbeea036848e
-size 3101345

--- a/samples/shared/screenshots/android/LiquidScreenshotTest.capture_sticky_header_10_dp_frost_scrolled[36].png
+++ b/samples/shared/screenshots/android/LiquidScreenshotTest.capture_sticky_header_10_dp_frost_scrolled[36].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a917725c6b5b6df91b8152cb223ca61cda6f0afc322f3d36d48d6a03ff77c804
+size 3101410

--- a/samples/shared/screenshots/android/LiquidScreenshotTest.capture_sticky_header_no_frost_scrolled[35].png
+++ b/samples/shared/screenshots/android/LiquidScreenshotTest.capture_sticky_header_no_frost_scrolled[35].png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:700978de3117582e0356f241dd80ef332baf41f80f3353fae4b4e37ac8f48c71
-size 3169238

--- a/samples/shared/screenshots/android/LiquidScreenshotTest.capture_sticky_header_no_frost_scrolled[36].png
+++ b/samples/shared/screenshots/android/LiquidScreenshotTest.capture_sticky_header_no_frost_scrolled[36].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9de4ca0d6f4c955a3da395d9526529f13ed37368945193d4e8e11299c7b587d2
+size 3169240


### PR DESCRIPTION
- Glad I did this as I didn't realize roborazzi was no longer running for Android.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
