### PR TITLE
Removed `by` delegation in Gradle now that it is deprecated

### DIFF
--- a/build-logic/convention/src/main/kotlin/AndroidMultiplatformLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidMultiplatformLibraryConventionPlugin.kt
@@ -26,6 +26,8 @@ class AndroidMultiplatformLibraryConventionPlugin : Plugin<Project> {
             instrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
           }
 
+          withHostTest { isIncludeAndroidResources = true }
+
           packaging {
             resources {
               excludes += "/META-INF/{AL2.0,LGPL2.1}"

--- a/core/testing/build.gradle.kts
+++ b/core/testing/build.gradle.kts
@@ -10,10 +10,7 @@ plugins {
 }
 
 kotlin {
-  android {
-    namespace = "io.github.fletchmckee.liquid.core.testing"
-    withHostTest { isIncludeAndroidResources = true }
-  }
+  android { namespace = "io.github.fletchmckee.liquid.core.testing" }
 
   iosArm64()
   iosSimulatorArm64()

--- a/liquid/build.gradle.kts
+++ b/liquid/build.gradle.kts
@@ -33,7 +33,8 @@ kotlin {
       implementation(libs.jetbrains.compose.foundation)
     }
 
-    val skikoMain by registering { dependsOn(commonMain.get()) }
+    val skikoMain = register("skikoMain")
+    skikoMain { dependsOn(commonMain.get()) }
 
     iosMain { dependsOn(skikoMain.get()) }
     macosMain { dependsOn(skikoMain.get()) }

--- a/liquid/src/androidMain/kotlin/io/github/fletchmckee/liquid/internal/LiquidBackupElement.android.kt
+++ b/liquid/src/androidMain/kotlin/io/github/fletchmckee/liquid/internal/LiquidBackupElement.android.kt
@@ -114,8 +114,6 @@ private fun Outline.asPath(): Path = when (this) {
   is Outline.Generic -> path
 }
 
-// This won't be that accurate, but we should at least provide an edge-like inner border using gradients
-// if the user provided a value.
 private fun ContentDrawScope.drawBackupEdgeEffect(shapePath: Path) = clipPath(shapePath) {
   val strokeWidth = 4.dp.toPx()
   val radius = size.minDimension

--- a/liquid/src/commonMain/kotlin/io/github/fletchmckee/liquid/internal/AbstractLiquidElement.kt
+++ b/liquid/src/commonMain/kotlin/io/github/fletchmckee/liquid/internal/AbstractLiquidElement.kt
@@ -35,14 +35,13 @@ import kotlin.math.PI
 import kotlin.math.atan2
 import kotlin.math.sqrt
 
-// We have separate nodes so that Android and Skiko can create their RuntimeShader/RuntimeEffect
-// in `init` rather than the draw pass as this has shown better performance.
+// Nodes are separated so that RuntimeShader/RuntimeEffect can be created once.
 internal expect fun liquidElement(
   liquidState: LiquidState,
   block: LiquidScope.() -> Unit,
 ): AbstractLiquidElement<out AbstractLiquidNode>
 
-// The `positionOnScreen()` doesn't return the same thing between Android and Skiko.
+// `positionOnScreen()` doesn't return the same thing between Android and Skiko.
 internal expect fun LayoutCoordinates.liquidPositionOnScreen(): Offset
 
 internal abstract class AbstractLiquidElement<N : AbstractLiquidNode>(
@@ -92,46 +91,23 @@ internal abstract class AbstractLiquidNode(
   private var cachedLayer: GraphicsLayer? = null
   private var cachedRenderEffect: RenderEffect? = null
 
-  /**
-   * Called when [renderEffectFlags] is mutated, signaling it needs to be created, recreated
-   * or set to null.
-   */
+  // Invoked when [renderEffectFlags] is mutated
   protected abstract fun createRenderEffect(): RenderEffect?
-
-  /**
-   * Called when [invalidateFlags] is mutated which means we're going to call [invalidateDraw],
-   * but before we clean the dirty tracker.
-   *
-   * The purpose of this method is to give consumers the chance to check the tracker for specific
-   * fields as they may contain cached effects unrelated to the RenderEffect.
-   */
+  // Invoked when [invalidateFlags] is mutated.
   protected open fun inspectDirtyFields() = Unit
-
-  /**
-   * Apply any additional effects to the [layer] unrelated to the RenderEffect. Any changes to the
-   * layer's renderEffect property are ignored as this is controlled by [createRenderEffect].
-   *
-   * @param layer The composite layer with the appropriate liquefiables recorded into place.
-   * @param drawBlock The block for drawing any additional effects. The default implementation invokes
-   * this block immediately with no additional effects.
-   */
+  // Apply additional effects unrelated to the RenderEffect
   protected open fun ContentDrawScope.applyAdditionalEffects(
     layer: GraphicsLayer,
     drawBlock: () -> Unit,
   ) = drawBlock()
 
-  /** Triggers draw invalidation when mutated. */
   protected open val invalidateFlags: Int = Fields.InvalidateFlags
-
-  /** Resets the RenderEffect when mutated */
   protected open val renderEffectFlags: Int = Fields.RenderEffectFields
 
   internal fun invalidateLiquidBlock() {
     if (!isAttached) return
-    // Our frostRadius calculations rely on density. Setting it here prevents unnecessary RenderEffect
-    // invalidations in the draw pass.
+    // Updating density/layoutDirection here prevents unnecessary RenderEffect invalidations in the draw pass.
     reusableScope.density = currentValueOf(LocalDensity)
-    // The cornerRadii ordering depends on layoutDirection.
     reusableScope.layoutDirection = currentValueOf(LocalLayoutDirection)
     block(reusableScope)
 
@@ -142,8 +118,6 @@ internal abstract class AbstractLiquidNode(
     }
     reusableScope.liquefiables = liquidState.liquefiables.fastFilter { it != ancestor }
 
-    // This avoids unnecessary invalidateDraw calls as this could be called multiple times before we have
-    // a valid size and position.
     if (reusableScope.size.isSpecified) {
       invalidateDrawIfNeeded()
     }
@@ -156,8 +130,7 @@ internal abstract class AbstractLiquidNode(
       if (reusableScope.mutatedFields has renderEffectFlags) {
         cachedRenderEffect = createRenderEffect()
       }
-      // It's important to call `clean()` after `createRenderEffect()` as the `createRenderEffect()`
-      // relies on the `mutatedFields` tracker to know when it has to be reconfigured.
+
       reusableScope.clean()
       invalidateDraw()
     }
@@ -168,11 +141,9 @@ internal abstract class AbstractLiquidNode(
       .createGraphicsLayer()
       .also { cachedLayer = it }
 
-  // We handle all necessary invalidations in LiquidScopeImpl.
+  // Performance optimization since we handle invalidations.
   override val shouldAutoInvalidate: Boolean = false
 
-  // The `observeReads` call is critical here, otherwise we won't receive updates from
-  // LiquidScope/Liquefiable property mutations.
   override fun onAttach() = observeReads(::invalidateLiquidBlock)
 
   override fun onDetach() {
@@ -218,7 +189,6 @@ internal abstract class AbstractLiquidNode(
       drawLayer(layer)
     }
 
-    // Necessary since it isn't part of the recording.
     drawContent()
   }
 }

--- a/liquid/src/commonMain/kotlin/io/github/fletchmckee/liquid/internal/AbstractLiquidElement.kt
+++ b/liquid/src/commonMain/kotlin/io/github/fletchmckee/liquid/internal/AbstractLiquidElement.kt
@@ -93,8 +93,10 @@ internal abstract class AbstractLiquidNode(
 
   // Invoked when [renderEffectFlags] is mutated
   protected abstract fun createRenderEffect(): RenderEffect?
+
   // Invoked when [invalidateFlags] is mutated.
   protected open fun inspectDirtyFields() = Unit
+
   // Apply additional effects unrelated to the RenderEffect
   protected open fun ContentDrawScope.applyAdditionalEffects(
     layer: GraphicsLayer,

--- a/liquid/src/commonMain/kotlin/io/github/fletchmckee/liquid/internal/InternalLiquidScope.kt
+++ b/liquid/src/commonMain/kotlin/io/github/fletchmckee/liquid/internal/InternalLiquidScope.kt
@@ -25,7 +25,7 @@ internal interface InternalLiquidScope : LiquidScope {
   var layoutDirection: LayoutDirection
   var size: Size
 
-  /**
+  /*
    * The GraphicsLayer `record` method requires IntSize.
    *
    * This exists just so that we don't have to call `toIntSize` for every draw operation,
@@ -39,7 +39,7 @@ internal interface InternalLiquidScope : LiquidScope {
   var boundsInRoot: Rect
   var liquefiables: List<Liquefiable>
 
-  /** Resets the `mutatedFields` dirty tracker. */
+  // Resets the `mutatedFields` dirty tracker.
   fun clean()
 }
 
@@ -60,8 +60,7 @@ internal class LiquidScopeImpl : InternalLiquidScope {
     set(value) {
       if (field != value) {
         field = value
-        // Similar to tint, we don't really care about the shape interface, we just need the corner radii,
-        // so the mutatedFields tracker is set there.
+        // Similar to tint, we just need the corner radii from Shape.
         if (size.isSpecified) {
           cornerRadii = value.normalizedCornerRadii(size, density, layoutDirection)
         }
@@ -138,8 +137,6 @@ internal class LiquidScopeImpl : InternalLiquidScope {
   override var layoutDirection: LayoutDirection = LayoutDirection.Ltr
     set(value) {
       if (field != value) {
-        // Doesn't need its own mutatedFields tracker as we only care about changes to cornerRadii.
-        // Also even if this did change frequently, most use cases will have uniform cornerRadii.
         field = value
         if (size.isSpecified) {
           cornerRadii = shape.normalizedCornerRadii(size, density, value)
@@ -235,8 +232,6 @@ internal class LiquidScopeImpl : InternalLiquidScope {
   internal var argbColor: Int = 0 // Same as Color.Unspecified.toArgb()
     private set(value) {
       if (field != value) {
-        // We set the mutatedFields on this internal property rather than the public `tint` property because
-        // ultimately this is the value we pass to the shader.
         mutatedFields = mutatedFields or Fields.Tint
         field = value
       }
@@ -264,7 +259,7 @@ internal class LiquidScopeImpl : InternalLiquidScope {
 
 @Suppress("ConstPropertyName")
 internal object Fields {
-  // A change in these requires recreating the RenderEffect and invalidating the draw.
+  // A change in these require recreating the RenderEffect and invalidating the draw.
   const val Frost: Int = 0b1
   const val Shape: Int = 0b1 shl 1
   const val Refraction: Int = 0b1 shl 2
@@ -285,7 +280,6 @@ internal object Fields {
   const val Liquefiables: Int = 0b1 shl 14
   const val BoundsInRoot: Int = 0b1 shl 15
 
-  // PositionOnScreen isn't a shader uniform as it's only used to translate liquefiables into the correct space.
   const val RenderEffectFields: Int =
     Frost or
       Shape or

--- a/liquid/src/commonMain/kotlin/io/github/fletchmckee/liquid/internal/LiquefiableElement.kt
+++ b/liquid/src/commonMain/kotlin/io/github/fletchmckee/liquid/internal/LiquefiableElement.kt
@@ -106,11 +106,9 @@ internal class LiquefiableNode(
       drawContent()
       return
     }
-    // Prevents double reads with the mutableState `liquefiable.layer` when `createGraphicsLayer` is called.
+    // Prevents double reads with the mutableState `liquefiable.layer` when `createGraphicsLayer` is invoked.
     val contentLayer = Snapshot.withoutReadObservation { obtainGraphicsLayer() }
-    // Record the content into the layer
     contentLayer.record { this@draw.drawContent() }
-    // No need to call drawContent since we did so in the recording.
     drawLayer(contentLayer)
   }
 }

--- a/liquid/src/commonMain/kotlin/io/github/fletchmckee/liquid/internal/drawUtil.kt
+++ b/liquid/src/commonMain/kotlin/io/github/fletchmckee/liquid/internal/drawUtil.kt
@@ -33,7 +33,7 @@ internal fun ContentDrawScope.recordLiquefiablesIntoLayer(
       liquefiable.layer
         ?.takeUnless { it.isReleased }
         ?.let { liquefiableLayer ->
-          // All the positioning calculations are based on the `topLeft` coordinate.
+          // All positioning calculations are based on the `topLeft` coordinate.
           val (x, y) = liquefiable.boundsOnScreen.topLeft - positionOnScreen
           withTransform(
             {

--- a/liquid/src/commonMain/kotlin/io/github/fletchmckee/liquid/internal/drawUtil.kt
+++ b/liquid/src/commonMain/kotlin/io/github/fletchmckee/liquid/internal/drawUtil.kt
@@ -27,14 +27,13 @@ internal fun ContentDrawScope.recordLiquefiablesIntoLayer(
   // Only record content inside the effect's bounds.
   val liquefiables = liquefiables.fastFilter { boundsInRoot.overlaps(it.boundsOnScreen) }
   if (liquefiables.isEmpty()) return@with
-  // We avoid unnecessary liquidScope invalidations by observing the mutableState boundsOnScreen
-  // and layers here. Changes to these properties will recompose the full draw pass.
+
   layer.record(intSize) {
     liquefiables.fastForEach { liquefiable ->
       liquefiable.layer
         ?.takeUnless { it.isReleased }
         ?.let { liquefiableLayer ->
-          // Position content where it should appear on screen.
+          // All the positioning calculations are based on the `topLeft` coordinate.
           val (x, y) = liquefiable.boundsOnScreen.topLeft - positionOnScreen
           withTransform(
             {
@@ -50,10 +49,7 @@ internal fun ContentDrawScope.recordLiquefiablesIntoLayer(
   }
 }
 
-/**
- * Allows passing a [Shape] parameter to a composable that can be used for other GraphicsLayer requirements
- * along with being used in our liquid nodes.
- */
+// Calculate the corner radii once upfront instead of in the shader.
 @androidx.annotation.Size(value = 4)
 internal fun Shape.normalizedCornerRadii(
   size: Size,

--- a/liquid/src/skikoMain/kotlin/io/github/fletchmckee/liquid/internal/LiquidElement.skiko.kt
+++ b/liquid/src/skikoMain/kotlin/io/github/fletchmckee/liquid/internal/LiquidElement.skiko.kt
@@ -20,10 +20,7 @@ internal actual fun liquidElement(
   block: LiquidScope.() -> Unit,
 ): AbstractLiquidElement<out AbstractLiquidNode> = LiquidElement(liquidState, block)
 
-/**
- * Using `positionOnScreen()` results in incorrect positioning. Will need to monitor if this
- * changes in the future.
- */
+// Using `positionOnScreen()` results in incorrect positioning for jvm.
 internal actual fun LayoutCoordinates.liquidPositionOnScreen(): Offset = positionInWindow()
 
 internal class LiquidElement(
@@ -58,7 +55,6 @@ internal class LiquidNode(
       else -> null
     }.also { cachedBlurImageFilter = it }
 
-    // Logic differs from Android slightly as we can set the blurEffect as an input.
     return ImageFilter.makeRuntimeShader(
       runtimeShaderBuilder = liquidShader,
       shaderNames = arrayOf("content"),

--- a/samples/shared/build.gradle.kts
+++ b/samples/shared/build.gradle.kts
@@ -21,7 +21,6 @@ kotlin {
   android {
     namespace = "io.github.fletchmckee.liquid.samples.shared"
     androidResources.enable = true
-    withHostTest { isIncludeAndroidResources = true }
   }
 
   listOf(


### PR DESCRIPTION
Also cleaned up the overly verbose comments I had for internal code.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
