### PR TITLE
Use lazy logic for Android multiplatform test setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,6 @@ jobs:
           check
           -x test
           -x allTests
-          -x testAndroidHostTest
           -x iosSimulatorArm64Test
           -x macosArm64Test
           -x jsBrowserTest

--- a/build-logic/convention/src/main/kotlin/AndroidMultiplatformLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidMultiplatformLibraryConventionPlugin.kt
@@ -1,5 +1,7 @@
 // Copyright 2025, Colin McKee
 // SPDX-License-Identifier: Apache-2.0
+import com.android.build.api.dsl.KotlinMultiplatformAndroidDeviceTestCompilation
+import com.android.build.api.dsl.KotlinMultiplatformAndroidHostTestCompilation
 import com.android.build.api.dsl.KotlinMultiplatformAndroidLibraryTarget
 import io.github.fletchmckee.buildlogic.Versions
 import org.gradle.api.Plugin
@@ -20,13 +22,14 @@ class AndroidMultiplatformLibraryConventionPlugin : Plugin<Project> {
           compileSdk = Versions.CompileSdk
           minSdk = Versions.MinSdk
 
-          withDeviceTestBuilder {
-            sourceSetTreeName = KotlinSourceSetTree.test.name
-          }.configure {
+          compilations.withType(KotlinMultiplatformAndroidDeviceTestCompilation::class.java).configureEach {
+            targetSdk { version = release(Versions.CompileSdk) }
             instrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
           }
 
-          withHostTest { isIncludeAndroidResources = true }
+          compilations.withType(KotlinMultiplatformAndroidHostTestCompilation::class.java).configureEach {
+            isIncludeAndroidResources = true
+          }
 
           packaging {
             resources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,6 +25,7 @@ org.gradle.caching=true
 org.gradle.parallel=true
 org.gradle.configuration-cache=true
 org.gradle.configureondemand=false
+org.gradle.tooling.parallel=true
 
 # Multiplatform
 org.jetbrains.compose.experimental.uikit.enabled=true

--- a/liquid/build.gradle.kts
+++ b/liquid/build.gradle.kts
@@ -4,6 +4,7 @@ import com.vanniktech.maven.publish.JavadocJar
 import com.vanniktech.maven.publish.KotlinMultiplatform
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation
+import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSetTree
 
 plugins {
   alias(libs.plugins.liquid.kotlin.multiplatform)
@@ -42,6 +43,7 @@ kotlin {
   android {
     namespace = "io.github.fletchmckee.liquid"
     androidResources.enable = true
+    withDeviceTestBuilder { sourceSetTreeName = KotlinSourceSetTree.test.name }
   }
 
   sourceSets {
@@ -65,7 +67,7 @@ kotlin {
       implementation(libs.jetbrains.compose.uiTest)
     }
 
-    androidDeviceTest.dependencies {
+    getByName("androidDeviceTest").dependencies {
       implementation(libs.androidx.junit)
       implementation(libs.compose.test.manifest)
     }


### PR DESCRIPTION
Not sure if withDeviceTestBuilder needed to be moved, but withHostTest was eager in a convention plugin https://developer.android.com/kotlin/multiplatform/kmp-integration#configure-test-compilations.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
